### PR TITLE
fix: robust site existence check in CI/CD deploy

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -94,7 +94,7 @@ jobs:
               sleep 5
             done
             echo '>>> Checking if site exists...'
-            if ! docker compose exec -T backend bench --site frontend list-apps >/dev/null 2>&1; then
+            if ! docker compose exec -T backend bash -c '[ -d sites/frontend ]' 2>/dev/null; then
               echo '>>> Creating site...'; docker compose run --rm create-site
             fi
             echo '>>> Running migrations...'
@@ -170,7 +170,7 @@ jobs:
               sleep 5
             done
             echo '>>> Checking if site exists...'
-            if ! docker compose exec -T backend bench --site frontend list-apps >/dev/null 2>&1; then
+            if ! docker compose exec -T backend bash -c '[ -d sites/frontend ]' 2>/dev/null; then
               echo '>>> Creating site...'; docker compose run --rm create-site
             fi
             echo '>>> Running migrations...'
@@ -246,7 +246,7 @@ jobs:
               sleep 5
             done
             echo '>>> Checking if site exists...'
-            if ! docker compose exec -T backend bench --site frontend list-apps >/dev/null 2>&1; then
+            if ! docker compose exec -T backend bash -c '[ -d sites/frontend ]' 2>/dev/null; then
               echo '>>> Creating site...'; docker compose run --rm create-site
             fi
             echo '>>> Running migrations...'


### PR DESCRIPTION
## Summary
- Fix CI/CD deploy failure on develop branch
- Change site existence check from `bench list-apps` to `[ -d sites/frontend ]`
- Previous check failed when site existed but bench command returned non-zero for other reasons
- Caused 'Site frontend already exists' error on re-deploys after manual DB reset

## Change
`.github/workflows/build-push.yml`: Updated site check in all 3 deploy jobs (staging, cheese, viventi)