### PR TITLE
Enhance site existence check and enable scheduler for frontend

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -94,7 +94,7 @@ jobs:
               sleep 5
             done
             echo '>>> Checking if site exists...'
-            if ! docker compose exec -T backend bench --site frontend list-apps >/dev/null 2>&1; then
+            if ! docker compose exec -T backend bash -c '[ -d sites/frontend ]' 2>/dev/null; then
               echo '>>> Creating site...'; docker compose run --rm create-site
             fi
             echo '>>> Running migrations...'
@@ -170,7 +170,7 @@ jobs:
               sleep 5
             done
             echo '>>> Checking if site exists...'
-            if ! docker compose exec -T backend bench --site frontend list-apps >/dev/null 2>&1; then
+            if ! docker compose exec -T backend bash -c '[ -d sites/frontend ]' 2>/dev/null; then
               echo '>>> Creating site...'; docker compose run --rm create-site
             fi
             echo '>>> Running migrations...'
@@ -246,7 +246,7 @@ jobs:
               sleep 5
             done
             echo '>>> Checking if site exists...'
-            if ! docker compose exec -T backend bench --site frontend list-apps >/dev/null 2>&1; then
+            if ! docker compose exec -T backend bash -c '[ -d sites/frontend ]' 2>/dev/null; then
               echo '>>> Creating site...'; docker compose run --rm create-site
             fi
             echo '>>> Running migrations...'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
         done;
         echo "sites/common_site_config.json found";
         bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext --install-app hrms --install-app payments --install-app cheese --set-default frontend;
+        bench --site frontend enable-scheduler;
     environment:
       TZ: UTC
       PGTZ: UTC


### PR DESCRIPTION
This pull request updates the site existence check logic in the GitHub Actions workflow and ensures the scheduler is enabled for the `frontend` site during site creation. The main changes improve reliability of site detection and automate scheduler setup.

**Workflow improvements:**

* Updated the site existence check in `.github/workflows/build-push.yml` to use a direct directory check (`[ -d sites/frontend ]`) instead of relying on the `bench` command, making the check more robust and less dependent on Frappe internals. [[1]](diffhunk://#diff-43c93d8fb63d2b17115bf33b86f825c3ec37507c6f869bb973e31e73341107ccL97-R97) [[2]](diffhunk://#diff-43c93d8fb63d2b17115bf33b86f825c3ec37507c6f869bb973e31e73341107ccL173-R173) [[3]](diffhunk://#diff-43c93d8fb63d2b17115bf33b86f825c3ec37507c6f869bb973e31e73341107ccL249-R249)

**Site setup automation:**

* Added a command to enable the scheduler for the `frontend` site (`bench --site frontend enable-scheduler`) in `docker-compose.yml`, ensuring scheduled jobs run automatically after site creation.