### PR TITLE
Enhance permission handling in various controllers

### DIFF
--- a/cheese/api/v1/attendance_controller.py
+++ b/cheese/api/v1/attendance_controller.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime, getdate, cint, get_datetime
 from cheese.api.common.responses import success, created, error, not_found, validation_error, paginated_response
+from cheese.cheese.utils.access import assert_record_access, assert_company_value, scope_filters
 
 
 @frappe.whitelist()
@@ -73,7 +74,9 @@ def manual_check_in(contact_id=None, ticket_id=None, reservation_code=None):
 		
 		if not ticket:
 			return not_found("Ticket", "not found")
-		
+
+		assert_record_access("Cheese Ticket", ticket.name)
+
 		# Validate ticket can be checked in
 		if ticket.status != "CONFIRMED":
 			return validation_error(
@@ -154,7 +157,9 @@ def get_attendance_record(attendance_id):
 		
 		if not frappe.db.exists("Cheese Attendance", attendance_id):
 			return not_found("Attendance", attendance_id)
-		
+
+		assert_record_access("Cheese Attendance", attendance_id)
+
 		attendance = frappe.get_doc("Cheese Attendance", attendance_id)
 		ticket = frappe.get_doc("Cheese Ticket", attendance.ticket)
 		
@@ -202,9 +207,14 @@ def list_attendance(
 	try:
 		page = cint(page) or 1
 		page_size = cint(page_size) or 20
-		
-		# Build filters
-		filters = {}
+
+		# Block parameter-override leaks for scoped users.
+		assert_company_value(company_id)
+		assert_company_value(establishment_id)
+
+		# Build filters. Cheese Attendance carries its own `company` column, so
+		# scope_filters enforces tenant isolation directly on the attendance query.
+		filters = scope_filters({})
 		
 		# Get tickets matching filters first
 		ticket_filters = {}
@@ -325,7 +335,9 @@ def mark_no_show_manual(ticket_id, reason=None):
 		
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
-		
+
+		assert_record_access("Cheese Ticket", ticket_id)
+
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
 		if ticket.status not in ["CONFIRMED"]:

--- a/cheese/api/v1/bank_account_controller.py
+++ b/cheese/api/v1/bank_account_controller.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import frappe
 from cheese.api.common.responses import error, not_found, success, validation_error
+from cheese.cheese.utils.access import assert_entity_access
 
 
 def serialize_company_bank_account_row(row):
@@ -83,6 +84,11 @@ def get_entity_bank_account(entity_type, entity_id):
 
 		if not frappe.db.exists(entity_type, entity_id):
 			return not_found(entity_type, entity_id)
+
+		try:
+			assert_entity_access(entity_type, entity_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		bank_account = get_active_bank_account_doc(entity_type, entity_id)
 		if not bank_account:

--- a/cheese/api/v1/booking_controller.py
+++ b/cheese/api/v1/booking_controller.py
@@ -7,6 +7,8 @@ from frappe.utils import now_datetime, add_to_date, getdate
 from cheese.api.common.responses import success, created, error, not_found, validation_error
 from cheese.api.v1.ticket_controller import create_pending_ticket
 from cheese.api.v1.route_booking_controller import create_route_reservation, get_route_status
+from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.access import assert_contact_access
 import json
 
 
@@ -39,6 +41,11 @@ def create_pending_booking(contact_id, items, preferred_dates=None, conversation
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
+
+		try:
+			assert_contact_access(contact_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 		
 		# Parse items
 		if isinstance(items, str):
@@ -299,15 +306,21 @@ def get_booking_status(booking_id):
 		# This ensures we only get tickets from the same booking
 		window_start = add_to_date(booking_time, minutes=-2, as_datetime=True)
 		window_end = add_to_date(booking_time, minutes=2, as_datetime=True)
-		
+
+		ticket_filters = [
+			["contact", "=", contact_id],
+			["creation", ">=", window_start],
+			["creation", "<=", window_end],
+			["status", "!=", "CANCELLED"]
+		]
+		# Tenant isolation: scoped users only see their own company's components.
+		user_company = _get_current_user_company()
+		if user_company:
+			ticket_filters.append(["company", "=", user_company])
+
 		tickets = frappe.get_all(
 			"Cheese Ticket",
-			filters=[
-				["contact", "=", contact_id],
-				["creation", ">=", window_start],
-				["creation", "<=", window_end],
-				["status", "!=", "CANCELLED"]
-			],
+			filters=ticket_filters,
 			fields=["name", "status", "route", "experience", "slot", "creation"],
 			order_by="creation asc"
 		)

--- a/cheese/api/v1/complaint_controller.py
+++ b/cheese/api/v1/complaint_controller.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.utils import now_datetime
 from cheese.api.common.responses import success, created, error, not_found, validation_error
 from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.access import assert_record_access, assert_contact_access, assert_company_value
 
 
 @frappe.whitelist()
@@ -36,11 +37,17 @@ def create_complaint(contact_id, description, ticket_id=None, route_booking_id=N
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
-		
-		# Validate ticket if provided
-		if ticket_id:
-			if not frappe.db.exists("Cheese Ticket", ticket_id):
-				return not_found("Ticket", ticket_id)
+
+		try:
+			assert_contact_access(contact_id)
+
+			# Validate ticket if provided
+			if ticket_id:
+				if not frappe.db.exists("Cheese Ticket", ticket_id):
+					return not_found("Ticket", ticket_id)
+				assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 		
 		# Create support case
 		support_case = frappe.get_doc({
@@ -101,7 +108,12 @@ def update_support_case_status(support_case_id, status, notes=None, assigned_to=
 		
 		if not frappe.db.exists("Cheese Support Case", support_case_id):
 			return not_found("Support Case", support_case_id)
-		
+
+		try:
+			assert_record_access("Cheese Support Case", support_case_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		support_case = frappe.get_doc("Cheese Support Case", support_case_id)
 		old_status = support_case.status
 		
@@ -154,7 +166,9 @@ def list_support_cases(status=None, contact_id=None, assigned_to=None, route_id=
 		Success response with support cases
 	"""
 	try:
-		# Apply company scoping for establishment admins
+		# Apply company scoping for establishment admins. Block parameter-override
+		# leaks first, then force the scoped user's own company.
+		assert_company_value(company_id)
 		user_company = _get_current_user_company()
 		if user_company:
 			company_id = user_company
@@ -167,14 +181,13 @@ def list_support_cases(status=None, contact_id=None, assigned_to=None, route_id=
 		if assigned_to:
 			filters["assigned_to"] = assigned_to
 
-		if route_id or company_id:
-			ticket_filters = {}
-			if route_id:
-				ticket_filters["route"] = route_id
-			if company_id:
-				ticket_filters["company"] = company_id
+		# Cheese Support Case carries its own `company` column; filter on it
+		# directly so ticketless (GENERAL) cases are scoped too.
+		if company_id:
+			filters["company"] = company_id
 
-			ticket_ids = frappe.get_all("Cheese Ticket", filters=ticket_filters, pluck="name")
+		if route_id:
+			ticket_ids = frappe.get_all("Cheese Ticket", filters={"route": route_id}, pluck="name")
 			if not ticket_ids:
 				from cheese.api.common.responses import paginated_response
 				return paginated_response([], "Support cases retrieved successfully", page=page, page_size=page_size, total=0)

--- a/cheese/api/v1/contact_controller.py
+++ b/cheese/api/v1/contact_controller.py
@@ -5,6 +5,7 @@ import frappe
 import json
 from frappe import _
 from cheese.api.common.responses import success, created, validation_error, error, not_found
+from cheese.cheese.utils.access import assert_contact_access, assert_company_value, scope_filters
 
 
 @frappe.whitelist()
@@ -162,6 +163,11 @@ def append_company_to_contact(contact_id=None, company_id=None, notes=None):
 		if not frappe.db.exists("Company", company_id):
 			return not_found("Company", company_id)
 
+		# Tenant isolation: scoped users may only act on their own contacts and
+		# may only link their own company.
+		assert_contact_access(contact_id)
+		assert_company_value(company_id)
+
 		contact = frappe.get_doc("Cheese Contact", contact_id)
 		existing = {row.company for row in (contact.get("companies") or [])}
 
@@ -225,7 +231,9 @@ def update_contact(contact_id, name=None, phone=None, email=None, preferred_lang
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
-		
+
+		assert_contact_access(contact_id)
+
 		contact = frappe.get_doc("Cheese Contact", contact_id)
 		
 		# Track changed fields
@@ -368,40 +376,42 @@ def get_contact_profile(contact_id):
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
-		
+
+		assert_contact_access(contact_id)
+
 		contact = frappe.get_doc("Cheese Contact", contact_id)
 		
-		# Get leads
+		# Get leads (scoped to the user's company)
 		leads = frappe.get_all(
 			"Cheese Lead",
-			filters={"contact": contact_id},
+			filters=scope_filters({"contact": contact_id}),
 			fields=["name", "status", "interest_type", "last_interaction_at", "lost_reason"],
 			order_by="modified desc",
 			limit=10
 		)
 		
-		# Get conversations
+		# Get conversations (scoped to the user's company)
 		conversations = frappe.get_all(
 			"Conversation",
-			filters={"contact": contact_id},
+			filters=scope_filters({"contact": contact_id}),
 			fields=["name", "channel", "status", "summary", "modified"],
 			order_by="modified desc",
 			limit=10
 		)
 		
-		# Get reservations/tickets
+		# Get reservations/tickets (scoped to the user's company)
 		reservations = frappe.get_all(
 			"Cheese Ticket",
-			filters={"contact": contact_id},
+			filters=scope_filters({"contact": contact_id}),
 			fields=["name", "status", "experience", "slot", "party_size", "created", "modified"],
 			order_by="modified desc",
 			limit=10
 		)
 		
-		# Get quotations
+		# Get quotations (constrained to the scoped leads above)
 		quotations = frappe.get_all(
 			"Cheese Quotation",
-			filters={"lead": ["in", [lead.name for lead in leads]]},
+			filters={"lead": ["in", [lead.name for lead in leads] or [""]]},
 			fields=["name", "status", "total_price", "deposit_amount", "valid_until"],
 			order_by="modified desc",
 			limit=5
@@ -455,20 +465,23 @@ def get_contact_leads(contact_id, page=1, page_size=20):
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
-		
+
+		assert_contact_access(contact_id)
+
 		page = cint(page) or 1
 		page_size = cint(page_size) or 20
-		
+
+		lead_filters = scope_filters({"contact": contact_id})
 		leads = frappe.get_all(
 			"Cheese Lead",
-			filters={"contact": contact_id},
+			filters=lead_filters,
 			fields=["name", "status", "interest_type", "last_interaction_at", "lost_reason", "conversation", "modified"],
 			limit_start=(page - 1) * page_size,
 			limit_page_length=page_size,
 			order_by="modified desc"
 		)
 		
-		total = frappe.db.count("Cheese Lead", {"contact": contact_id})
+		total = frappe.db.count("Cheese Lead", lead_filters)
 		
 		return paginated_response(
 			leads,
@@ -504,20 +517,23 @@ def get_contact_conversations(contact_id, page=1, page_size=20):
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
-		
+
+		assert_contact_access(contact_id)
+
 		page = cint(page) or 1
 		page_size = cint(page_size) or 20
-		
+
+		conv_filters = scope_filters({"contact": contact_id})
 		conversations = frappe.get_all(
 			"Conversation",
-			filters={"contact": contact_id},
+			filters=conv_filters,
 			fields=["name", "channel", "status", "summary", "lead", "ticket", "route_booking", "modified"],
 			limit_start=(page - 1) * page_size,
 			limit_page_length=page_size,
 			order_by="modified desc"
 		)
 		
-		total = frappe.db.count("Conversation", {"contact": contact_id})
+		total = frappe.db.count("Conversation", conv_filters)
 		
 		return paginated_response(
 			conversations,
@@ -553,13 +569,16 @@ def get_contact_reservations(contact_id, page=1, page_size=20):
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
-		
+
+		assert_contact_access(contact_id)
+
 		page = cint(page) or 1
 		page_size = cint(page_size) or 20
-		
+
+		ticket_filters = scope_filters({"contact": contact_id})
 		reservations = frappe.get_all(
 			"Cheese Ticket",
-			filters={"contact": contact_id},
+			filters=ticket_filters,
 			fields=["name", "status", "experience", "slot", "party_size", "company", "route", "created", "modified"],
 			limit_start=(page - 1) * page_size,
 			limit_page_length=page_size,
@@ -572,7 +591,7 @@ def get_contact_reservations(contact_id, page=1, page_size=20):
 				exp = frappe.db.get_value("Cheese Experience", reservation.experience, "name", as_dict=True)
 				reservation["experience_name"] = exp.name if exp else None
 		
-		total = frappe.db.count("Cheese Ticket", {"contact": contact_id})
+		total = frappe.db.count("Cheese Ticket", ticket_filters)
 		
 		return paginated_response(
 			reservations,

--- a/cheese/api/v1/conversation_controller.py
+++ b/cheese/api/v1/conversation_controller.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime, cint, add_to_date
 from cheese.api.common.responses import success, created, error, not_found, validation_error, paginated_response
+from cheese.cheese.utils.access import assert_record_access
 import json
 
 
@@ -243,7 +244,12 @@ def update_conversation_summary(conversation_id, summary=None, highlights_json=N
 		
 		if not frappe.db.exists("Conversation", conversation_id):
 			return not_found("Conversation", conversation_id)
-		
+
+		try:
+			assert_record_access("Conversation", conversation_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		conversation = frappe.get_doc("Conversation", conversation_id)
 		
 		if summary is not None:
@@ -300,7 +306,12 @@ def get_conversation_details(conversation_id):
 		
 		if not frappe.db.exists("Conversation", conversation_id):
 			return not_found("Conversation", conversation_id)
-		
+
+		try:
+			assert_record_access("Conversation", conversation_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		conversation = frappe.get_doc("Conversation", conversation_id)
 		
 		# Get contact details
@@ -460,21 +471,33 @@ def link_conversation_entity(conversation_id, entity_type, entity_id):
 		
 		if not frappe.db.exists("Conversation", conversation_id):
 			return not_found("Conversation", conversation_id)
-		
+
+		try:
+			assert_record_access("Conversation", conversation_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		conversation = frappe.get_doc("Conversation", conversation_id)
 		
-		# Validate entity exists
-		if entity_type == "lead":
-			if not frappe.db.exists("Cheese Lead", entity_id):
-				return not_found("Lead", entity_id)
-			conversation.lead = entity_id
-		elif entity_type == "ticket":
-			if not frappe.db.exists("Cheese Ticket", entity_id):
-				return not_found("Ticket", entity_id)
-			conversation.ticket = entity_id
-		elif entity_type == "route_booking":
-			# Route booking would be a string reference
-			conversation.route_booking = entity_id
+		# Validate entity exists and belongs to the user's company
+		try:
+			if entity_type == "lead":
+				if not frappe.db.exists("Cheese Lead", entity_id):
+					return not_found("Lead", entity_id)
+				assert_record_access("Cheese Lead", entity_id)
+				conversation.lead = entity_id
+			elif entity_type == "ticket":
+				if not frappe.db.exists("Cheese Ticket", entity_id):
+					return not_found("Ticket", entity_id)
+				assert_record_access("Cheese Ticket", entity_id)
+				conversation.ticket = entity_id
+			elif entity_type == "route_booking":
+				if frappe.db.exists("Cheese Route Booking", entity_id):
+					assert_record_access("Cheese Route Booking", entity_id)
+				# Route booking would be a string reference
+				conversation.route_booking = entity_id
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 		
 		conversation.save()
 		frappe.db.commit()
@@ -517,7 +540,12 @@ def append_conversation_event(conversation_id, event_type, event_data=None, meta
 		
 		if not frappe.db.exists("Conversation", conversation_id):
 			return not_found("Conversation", conversation_id)
-		
+
+		try:
+			assert_record_access("Conversation", conversation_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		# Parse event_data and metadata if strings
 		if isinstance(event_data, str):
 			try:

--- a/cheese/api/v1/dashboard_controller.py
+++ b/cheese/api/v1/dashboard_controller.py
@@ -263,6 +263,12 @@ def get_establishment_dashboard(establishment_id, period="today", date_from=None
 		Success response with establishment dashboard data
 	"""
 	try:
+		# Tenant isolation: scoped users are pinned to their own establishment
+		# regardless of the establishment_id passed by the client.
+		scope_company = _dashboard_company_scope()
+		if scope_company:
+			establishment_id = scope_company
+
 		if not establishment_id:
 			return validation_error("establishment_id is required")
 		

--- a/cheese/api/v1/deposit_controller.py
+++ b/cheese/api/v1/deposit_controller.py
@@ -8,6 +8,7 @@ from frappe.utils import add_to_date, flt, now_datetime
 from cheese.api.common.responses import created, error, not_found, success, validation_error
 from cheese.api.v1.bank_account_controller import get_active_company_bank_accounts_list
 from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.access import assert_record_access
 
 OPEN_DEPOSIT_STATUSES = ("PENDING", "OVERDUE")
 RECEIVED_DEPOSIT_STATUSES = ("PAID", "REVIEW", "ADJUSTED")
@@ -311,11 +312,20 @@ def get_payment_link_or_instructions(ticket_id=None, deposit_id=None, payment_ty
 		if deposit_id:
 			if not frappe.db.exists("Cheese Deposit", deposit_id):
 				return not_found("Deposit", deposit_id)
+			try:
+				assert_record_access("Cheese Deposit", deposit_id)
+			except frappe.PermissionError:
+				return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 			deposit_doc = frappe.get_doc("Cheese Deposit", deposit_id)
 			ticket_id = deposit_doc.entity_id if deposit_doc.entity_type == "Cheese Ticket" else None
 		else:
 			if not frappe.db.exists("Cheese Ticket", ticket_id):
 				return not_found("Ticket", ticket_id)
+
+			try:
+				assert_record_access("Cheese Ticket", ticket_id)
+			except frappe.PermissionError:
+				return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 			# If a Deposit-phase payment is requested but the ticket has no deposit requirement,
 			# return early — the Balance deposit should not be surfaced as a "Deposit".
@@ -436,6 +446,11 @@ def get_deposit_instructions(ticket_id, payment_type=None):
 
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		bank_account = _bank_accounts_for_ticket(ticket)
@@ -682,6 +697,10 @@ def record_deposit_payment(
 		if deposit_id:
 			if not frappe.db.exists("Cheese Deposit", deposit_id):
 				return not_found("Deposit", deposit_id)
+			try:
+				assert_record_access("Cheese Deposit", deposit_id)
+			except frappe.PermissionError:
+				return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 			deposit = frappe.get_doc("Cheese Deposit", deposit_id)
 			ticket_id = ticket_id or (deposit.entity_id if deposit.entity_type == "Cheese Ticket" else None)
 		else:
@@ -690,6 +709,11 @@ def record_deposit_payment(
 				entity_type = "Cheese Route Booking"
 			elif not frappe.db.exists("Cheese Ticket", ticket_id):
 				return not_found("Ticket or Route Booking", ticket_id)
+
+			try:
+				assert_record_access(entity_type, ticket_id)
+			except frappe.PermissionError:
+				return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 			# Get or auto-create deposit for this ticket
 			ticket_doc = frappe.get_doc(entity_type, ticket_id)
@@ -858,6 +882,11 @@ def verify_deposit(deposit_id):
 		if not frappe.db.exists("Cheese Deposit", deposit_id):
 			return not_found("Deposit", deposit_id)
 
+		try:
+			assert_record_access("Cheese Deposit", deposit_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		deposit = frappe.get_doc("Cheese Deposit", deposit_id)
 		old_status = deposit.status
 
@@ -915,6 +944,11 @@ def get_deposit_status(deposit_id):
 		if not frappe.db.exists("Cheese Deposit", deposit_id):
 			return not_found("Deposit", deposit_id)
 
+		try:
+			assert_record_access("Cheese Deposit", deposit_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		deposit = frappe.get_doc("Cheese Deposit", deposit_id)
 
 		return success(
@@ -951,6 +985,10 @@ def get_deposit(deposit_id):
 			return validation_error("deposit_id is required")
 		if not frappe.db.exists("Cheese Deposit", deposit_id):
 			return not_found("Deposit", deposit_id)
+		try:
+			assert_record_access("Cheese Deposit", deposit_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 		deposit = frappe.get_doc("Cheese Deposit", deposit_id)
 		return success("Deposit retrieved successfully", _build_deposit_payload(deposit))
 	except Exception as e:
@@ -975,6 +1013,11 @@ def mark_deposit_overdue(deposit_id):
 
 		if not frappe.db.exists("Cheese Deposit", deposit_id):
 			return not_found("Deposit", deposit_id)
+
+		try:
+			assert_record_access("Cheese Deposit", deposit_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		deposit = frappe.get_doc("Cheese Deposit", deposit_id)
 
@@ -1041,6 +1084,11 @@ def adjust_deposit(deposit_id, adjustment_reason, refund_amount=None):
 
 		if not frappe.db.exists("Cheese Deposit", deposit_id):
 			return not_found("Deposit", deposit_id)
+
+		try:
+			assert_record_access("Cheese Deposit", deposit_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		deposit = frappe.get_doc("Cheese Deposit", deposit_id)
 
@@ -1319,6 +1367,11 @@ def reconcile_deposit(deposit_id, bank_account_number=None):
 		if not frappe.db.exists("Cheese Deposit", deposit_id):
 			return not_found("Deposit", deposit_id)
 
+		try:
+			assert_record_access("Cheese Deposit", deposit_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		deposit = frappe.get_doc("Cheese Deposit", deposit_id)
 
 		# Use reconcile_ocr_payment method
@@ -1375,6 +1428,11 @@ def create_remaining_balance_deposit(ticket_id=None, route_booking_id=None):
 				return not_found("Ticket", entity_id)
 			entity_doc = frappe.get_doc(entity_type, entity_id)
 			total_price = _get_entity_total_price(entity_type, entity_doc)
+
+		try:
+			assert_record_access(entity_type, entity_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		existing_balance = _get_open_balance_deposit(entity_type, entity_id)
 		if existing_balance:

--- a/cheese/api/v1/document_controller.py
+++ b/cheese/api/v1/document_controller.py
@@ -453,6 +453,8 @@ def delete_document(document_id):
 				return not_found("Document", document_id)
 			
 			file_doc = frappe.get_doc("File", document_id)
+			if not _is_entity_accessible(file_doc.attached_to_doctype, file_doc.attached_to_name):
+				return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 			file_doc.delete()
 			frappe.db.commit()
 			

--- a/cheese/api/v1/establishment_controller.py
+++ b/cheese/api/v1/establishment_controller.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.utils import getdate, cint
 from cheese.api.common.responses import success, error, not_found, validation_error, paginated_response
 from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.access import assert_company_value
 from cheese.api.v1.bank_account_controller import (
 	get_active_company_bank_accounts_list,
 	get_active_company_bank_accounts_map,
@@ -144,6 +145,11 @@ def list_establishments(page=1, page_size=20, search=None, status=None, locality
 					total=0
 				)
 		
+		# Re-assert tenant scope: the tags/locality filters above may have widened
+		# `name`, so a scoped establishment user must always be pinned to their company.
+		if user_company:
+			filters["name"] = user_company
+
 		# Get companies - try with administrator_contact, fallback without it if field doesn't exist
 		company_fields_with_contact = ["name", "company_name", "email", "phone_no", "website", "company_description", "administrator_contact"]
 		company_fields_without_contact = ["name", "company_name", "email", "phone_no", "website", "company_description"]
@@ -270,7 +276,12 @@ def get_establishment_details(company_id):
 		
 		if not frappe.db.exists("Company", company_id):
 			return not_found("Company", company_id)
-		
+
+		try:
+			assert_company_value(company_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		company = frappe.get_doc("Company", company_id)
 		
 		# Get experiences
@@ -514,6 +525,11 @@ def delete_establishment(company_id):
 		if not frappe.db.exists("Company", company_id):
 			return not_found("Company", company_id)
 
+		try:
+			assert_company_value(company_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		blockers = _establishment_delete_blockers(company_id)
 		if blockers:
 			return validation_error(
@@ -541,6 +557,11 @@ def archive_establishment(company_id):
 		if not _company_has_cheese_archived():
 			return validation_error(_("Cheese archive field is not installed. Run bench migrate."))
 
+		try:
+			assert_company_value(company_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		frappe.db.set_value("Company", company_id, "cheese_archived", 1)
 		frappe.db.commit()
 		return success(
@@ -561,6 +582,11 @@ def unarchive_establishment(company_id):
 			return not_found("Company", company_id)
 		if not _company_has_cheese_archived():
 			return validation_error(_("Cheese archive field is not installed. Run bench migrate."))
+
+		try:
+			assert_company_value(company_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		frappe.db.set_value("Company", company_id, "cheese_archived", 0)
 		frappe.db.commit()
@@ -591,7 +617,12 @@ def update_establishment(company_id, **kwargs):
 		
 		if not frappe.db.exists("Company", company_id):
 			return not_found("Company", company_id)
-		
+
+		try:
+			assert_company_value(company_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		company = frappe.get_doc("Company", company_id)
 		
 		# Allowed fields for update (restrict operational fields)
@@ -672,7 +703,12 @@ def export_establishments(format="CSV", filters=None):
 				filter_dict = json.loads(filters) if isinstance(filters, str) else filters
 			except Exception:
 				pass
-		
+
+		# Tenant isolation: scoped users may only export their own establishment.
+		user_company = _get_current_user_company()
+		if user_company:
+			filter_dict["name"] = user_company
+
 		# Get all companies matching filters
 		companies = frappe.get_all(
 			"Company",
@@ -863,7 +899,12 @@ def upload_establishment_media(company_id, file_url, title, document_type="PDF",
 		
 		if not frappe.db.exists("Company", company_id):
 			return not_found("Company", company_id)
-		
+
+		try:
+			assert_company_value(company_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		# Use document controller
 		from cheese.api.v1.document_controller import upload_document
 		return upload_document(

--- a/cheese/api/v1/experience_controller.py
+++ b/cheese/api/v1/experience_controller.py
@@ -7,7 +7,7 @@ from frappe import _
 from frappe.utils import today, getdate, get_time, cint, get_datetime, get_url, add_days, add_months
 from cheese.api.common.responses import success, created, error, not_found, validation_error, paginated_response
 from cheese.api.v1.user_controller import _get_current_user_company
-from cheese.cheese.utils.access import assert_slot_access
+from cheese.cheese.utils.access import assert_slot_access, assert_experience_access
 from cheese.api.v1.bank_account_controller import (
 	get_active_company_bank_accounts_list,
 	get_active_company_bank_accounts_map,
@@ -88,13 +88,17 @@ def list_experiences(page=1, page_size=20, status=None, company=None, establishm
 
 		if date:
 			date_obj = getdate(date)
+			slot_filters = {
+				"date_from": ["<=", date_obj],
+				"date_to": [">=", date_obj],
+				"slot_status": ["in", ["OPEN", "CLOSED"]],
+			}
+			# Tenant isolation: only consider the user's own slots.
+			if user_company:
+				slot_filters["company"] = user_company
 			slots = frappe.get_all(
 				"Cheese Experience Slot",
-				filters={
-					"date_from": ["<=", date_obj],
-					"date_to": [">=", date_obj],
-					"slot_status": ["in", ["OPEN", "CLOSED"]],
-				},
+				filters=slot_filters,
 				fields=["name", "experience"],
 			)
 
@@ -328,7 +332,12 @@ def update_experience_pricing(experience_id, individual_price=None, route_price=
 		
 		if not frappe.db.exists("Cheese Experience", experience_id):
 			return not_found("Experience", experience_id)
-		
+
+		try:
+			assert_experience_access(experience_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		experience = frappe.get_doc("Cheese Experience", experience_id)
 		
 		if individual_price is not None:
@@ -399,6 +408,11 @@ def create_time_slot(experience_id, date, time, max_capacity, slot_status="OPEN"
 		
 		if not frappe.db.exists("Cheese Experience", experience_id):
 			return not_found("Experience", experience_id)
+
+		try:
+			assert_experience_access(experience_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		if getdate(date) < getdate(today()):
 			return validation_error("Cannot create a slot on an expired date")
@@ -610,7 +624,12 @@ def create_recurring_slots(experience_id, date_from, date_to, time_from=None, ti
 		
 		if not frappe.db.exists("Cheese Experience", experience_id):
 			return not_found("Experience", experience_id)
-		
+
+		try:
+			assert_experience_access(experience_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		start_date = getdate(date_from)
 		end_date = getdate(date_to)
 		today_date = getdate(today())
@@ -1080,6 +1099,11 @@ def link_booking_policy(experience_id, policy_id):
 		if not frappe.db.exists("Cheese Booking Policy", policy_id):
 			return not_found("Booking Policy", policy_id)
 
+		try:
+			assert_experience_access(experience_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		frappe.db.set_value(
 			"Cheese Experience",
 			experience_id,
@@ -1118,7 +1142,12 @@ def update_booking_policy(experience_id, cancel_until_hours_before=None, modify_
 		
 		if not frappe.db.exists("Cheese Experience", experience_id):
 			return not_found("Experience", experience_id)
-		
+
+		try:
+			assert_experience_access(experience_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		# Resolve the policy currently in use by this experience
 		# (new model: Experience.booking_policy; legacy: Booking Policy.experience back-ref)
 		from cheese.cheese.utils.validation import get_booking_policy_for_experience
@@ -1407,6 +1436,11 @@ def delete_experience(experience_id):
 
 		if not frappe.db.exists("Cheese Experience", experience_id):
 			return not_found("Experience", experience_id)
+
+		try:
+			assert_experience_access(experience_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		# Check for active tickets
 		active_tickets = frappe.db.count(

--- a/cheese/api/v1/hotel_controller.py
+++ b/cheese/api/v1/hotel_controller.py
@@ -147,6 +147,12 @@ def get_hotel_availability(experience_id, date_from=None, date_to=None, guests=N
         if not frappe.db.exists("Cheese Experience", experience_id):
             return not_found("Experience", experience_id)
 
+        # Tenant isolation (guest bot callers have no company and pass through).
+        try:
+            assert_experience_access(experience_id)
+        except frappe.PermissionError:
+            return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
         experience = frappe.get_doc("Cheese Experience", experience_id)
         if experience.experience_type != "HOTEL":
             return validation_error("Experience is not a HOTEL type")
@@ -456,9 +462,13 @@ def get_hotel_reservations(hotel_id=None, experience_id=None, date_from=None, da
         Paginated response with hotel reservations
     """
     try:
+        # Tenant isolation: scoped users are pinned to their own establishment
+        # regardless of the hotel_id passed (omitted hotel_id must not leak all).
         user_company = _get_current_user_company()
-        if user_company and hotel_id != user_company:
-            return paginated_response([], "Unauthorized", page=1, page_size=20, total=0)
+        if user_company:
+            if hotel_id and hotel_id != user_company:
+                return paginated_response([], "Unauthorized", page=1, page_size=20, total=0)
+            hotel_id = user_company
 
         page = cint(page) or 1
         page_size = cint(page_size) or 20

--- a/cheese/api/v1/itinerary_controller.py
+++ b/cheese/api/v1/itinerary_controller.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 from cheese.api.common.responses import success, error, not_found, validation_error
+from cheese.cheese.utils.access import assert_contact_access, scope_filters
 
 
 @frappe.whitelist()
@@ -23,14 +24,20 @@ def get_customer_itinerary(contact_id):
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
+
+		try:
+			assert_contact_access(contact_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 		
-		# Get all tickets for this contact
+		# Get all tickets for this contact (scoped to the user's company so an
+		# establishment user never sees the contact's cross-company reservations).
 		tickets = frappe.get_all(
 			"Cheese Ticket",
-			filters={
+			filters=scope_filters({
 				"contact": contact_id,
 				"status": ["not in", ["CANCELLED", "EXPIRED", "REJECTED"]]
-			},
+			}),
 			fields=["name", "status", "experience", "route", "slot", "party_size", "creation", "modified"],
 			order_by="creation desc"
 		)

--- a/cheese/api/v1/lead_controller.py
+++ b/cheese/api/v1/lead_controller.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime, cint
 from cheese.api.common.responses import success, created, error, not_found, validation_error, paginated_response
+from cheese.cheese.utils.access import assert_record_access, assert_contact_access, scope_filters
 
 
 @frappe.whitelist()
@@ -28,7 +29,9 @@ def upsert_lead(contact_id, conversation_id=None, interest_type=None, status=Non
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
-		
+
+		assert_contact_access(contact_id)
+
 		# Check for existing lead (any status except DISCARDED)
 		existing_lead = frappe.db.get_value(
 			"Cheese Lead",
@@ -199,7 +202,9 @@ def update_lead_status(lead_id, status, lost_reason=None):
 		
 		if not frappe.db.exists("Cheese Lead", lead_id):
 			return not_found("Lead", lead_id)
-		
+
+		assert_record_access("Cheese Lead", lead_id)
+
 		lead = frappe.get_doc("Cheese Lead", lead_id)
 		old_status = lead.status
 		
@@ -244,7 +249,9 @@ def get_lead_details(lead_id):
 		
 		if not frappe.db.exists("Cheese Lead", lead_id):
 			return not_found("Lead", lead_id)
-		
+
+		assert_record_access("Cheese Lead", lead_id)
+
 		lead = frappe.get_doc("Cheese Lead", lead_id)
 		
 		# Get contact details
@@ -313,7 +320,7 @@ def list_leads(page=1, page_size=20, status=None, contact_id=None, interest_type
 		page = cint(page) or 1
 		page_size = cint(page_size) or 20
 		
-		filters = {}
+		filters = scope_filters({})
 		if status:
 			filters["status"] = status
 		if contact_id:
@@ -376,7 +383,9 @@ def convert_lead_to_reservation(lead_id, experience_id, slot_id, party_size):
 		
 		if not frappe.db.exists("Cheese Lead", lead_id):
 			return not_found("Lead", lead_id)
-		
+
+		assert_record_access("Cheese Lead", lead_id)
+
 		lead = frappe.get_doc("Cheese Lead", lead_id)
 		
 		# Get contact from lead

--- a/cheese/api/v1/opt_in_controller.py
+++ b/cheese/api/v1/opt_in_controller.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime
 from cheese.api.common.responses import success, error, not_found, validation_error
+from cheese.cheese.utils.access import assert_contact_access
 
 
 @frappe.whitelist()
@@ -36,6 +37,11 @@ def update_opt_in_status(contact_id, channel, opt_in_status):
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
+
+		try:
+			assert_contact_access(contact_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 		
 		contact = frappe.get_doc("Cheese Contact", contact_id)
 		
@@ -96,6 +102,11 @@ def get_opt_in_status(contact_id, channel=None):
 		
 		if not frappe.db.exists("Cheese Contact", contact_id):
 			return not_found("Contact", contact_id)
+
+		try:
+			assert_contact_access(contact_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 		
 		contact = frappe.get_doc("Cheese Contact", contact_id)
 		

--- a/cheese/api/v1/pricing_controller.py
+++ b/cheese/api/v1/pricing_controller.py
@@ -7,6 +7,7 @@ from frappe.utils import get_datetime, now_datetime
 from cheese.api.common.responses import success, error, not_found, validation_error
 from cheese.cheese.utils.pricing import calculate_ticket_price, calculate_deposit_amount
 from cheese.cheese.utils.validation import validate_booking_policy
+from cheese.cheese.utils.access import assert_record_access
 import json
 
 
@@ -167,7 +168,12 @@ def get_modification_policy(reservation_id=None, experience_id=None):
 		if reservation_id:
 			if not frappe.db.exists("Cheese Ticket", reservation_id):
 				return not_found("Reservation", reservation_id)
-			
+
+			try:
+				assert_record_access("Cheese Ticket", reservation_id)
+			except frappe.PermissionError:
+				return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 			ticket = frappe.get_doc("Cheese Ticket", reservation_id)
 			experience_id_to_check = ticket.experience
 			
@@ -250,7 +256,12 @@ def get_cancellation_impact(reservation_id=None, experience_id=None, slot_dateti
 		if reservation_id:
 			if not frappe.db.exists("Cheese Ticket", reservation_id):
 				return not_found("Reservation", reservation_id)
-			
+
+			try:
+				assert_record_access("Cheese Ticket", reservation_id)
+			except frappe.PermissionError:
+				return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 			ticket = frappe.get_doc("Cheese Ticket", reservation_id)
 			experience_id_to_check = ticket.experience
 			

--- a/cheese/api/v1/qr_controller.py
+++ b/cheese/api/v1/qr_controller.py
@@ -7,6 +7,7 @@ from frappe.utils import now_datetime
 import secrets
 import string
 from cheese.api.common.responses import success, created, error, not_found, validation_error
+from cheese.cheese.utils.access import assert_record_access
 
 
 def _request_value(*keys):
@@ -82,7 +83,12 @@ def get_checkin_status(reservation_id):
 		
 		if not frappe.db.exists("Cheese Ticket", reservation_id):
 			return not_found("Reservation", reservation_id)
-		
+
+		try:
+			assert_record_access("Cheese Ticket", reservation_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", reservation_id)
 		
 		# Get attendance record
@@ -172,6 +178,11 @@ def get_qr(ticket_id=None, allow_pending=0, send_notification=0):
 
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
@@ -315,6 +326,10 @@ def validate_qr(token=None):
 			)
 
 		# Get ticket
+		try:
+			assert_record_access("Cheese Ticket", qr_token.ticket)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 		ticket = frappe.get_doc("Cheese Ticket", qr_token.ticket)
 
 		if ticket.status == "PENDING":
@@ -388,7 +403,12 @@ def resend_qr(ticket_id):
 		
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
-		
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
 		if ticket.status not in ["CONFIRMED", "CHECKED_IN"]:
@@ -439,7 +459,12 @@ def revoke_qr(ticket_id):
 		
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
-		
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		# Get QR token
 		qr_token = frappe.db.get_value(
 			"Cheese QR Token",

--- a/cheese/api/v1/quotation_controller.py
+++ b/cheese/api/v1/quotation_controller.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.utils import add_to_date, now_datetime, cint, get_datetime, getdate
 from cheese.api.common.responses import success, created, error, not_found, validation_error, paginated_response
 from cheese.cheese.utils.pricing import calculate_ticket_price, calculate_deposit_amount
+from cheese.cheese.utils.access import assert_record_access, scope_filters
 import json
 
 
@@ -32,7 +33,9 @@ def create_quotation(lead_id, conversation_id=None, route_id=None, experiences=N
 		
 		if not frappe.db.exists("Cheese Lead", lead_id):
 			return not_found("Lead", lead_id)
-		
+
+		assert_record_access("Cheese Lead", lead_id)
+
 		# Validate route or experiences
 		if route_id:
 			if not frappe.db.exists("Cheese Route", route_id):
@@ -163,7 +166,9 @@ def get_quotation_details(quotation_id):
 		
 		if not frappe.db.exists("Cheese Quotation", quotation_id):
 			return not_found("Quotation", quotation_id)
-		
+
+		assert_record_access("Cheese Quotation", quotation_id)
+
 		quotation = frappe.get_doc("Cheese Quotation", quotation_id)
 		
 		# Parse snapshot
@@ -216,7 +221,9 @@ def update_quotation_status(quotation_id, status):
 		
 		if not frappe.db.exists("Cheese Quotation", quotation_id):
 			return not_found("Quotation", quotation_id)
-		
+
+		assert_record_access("Cheese Quotation", quotation_id)
+
 		quotation = frappe.get_doc("Cheese Quotation", quotation_id)
 		old_status = quotation.status
 		quotation.status = status
@@ -255,7 +262,9 @@ def accept_quotation(quotation_id):
 		
 		if not frappe.db.exists("Cheese Quotation", quotation_id):
 			return not_found("Quotation", quotation_id)
-		
+
+		assert_record_access("Cheese Quotation", quotation_id)
+
 		quotation = frappe.get_doc("Cheese Quotation", quotation_id)
 		
 		# Validate quotation is not expired
@@ -341,7 +350,7 @@ def list_quotations(page=1, page_size=20, lead_id=None, status=None):
 		page = cint(page) or 1
 		page_size = cint(page_size) or 20
 		
-		filters = {}
+		filters = scope_filters({})
 		if lead_id:
 			filters["lead"] = lead_id
 		if status:
@@ -394,7 +403,9 @@ def validate_quotation_availability(quotation_id):
 		
 		if not frappe.db.exists("Cheese Quotation", quotation_id):
 			return not_found("Quotation", quotation_id)
-		
+
+		assert_record_access("Cheese Quotation", quotation_id)
+
 		quotation = frappe.get_doc("Cheese Quotation", quotation_id)
 		
 		# Parse snapshot

--- a/cheese/api/v1/route_booking_controller.py
+++ b/cheese/api/v1/route_booking_controller.py
@@ -12,6 +12,7 @@ from frappe.utils import add_to_date, get_datetime, getdate, now_datetime
 from cheese.api.common.responses import created, error, not_found, success, validation_error
 from cheese.api.v1.ticket_controller import create_pending_ticket
 from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.access import assert_route_access, assert_record_access
 from cheese.cheese.utils.capacity import (
 	get_available_capacity,
 	slot_calendar_days_in_range,
@@ -304,6 +305,11 @@ def get_route_combinations(route_id, date=None, date_from=None, date_to=None, pa
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
 
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return _permission_denied("Not permitted to access this route")
+
 		route = frappe.get_doc("Cheese Route", route_id)
 
 		if route.status != "ONLINE":
@@ -460,6 +466,11 @@ def create_route_reservation(
 
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
+
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return _permission_denied("Not permitted to access this route")
 
 		route = frappe.get_doc("Cheese Route", route_id)
 
@@ -1273,6 +1284,13 @@ def confirm_route_modification(route_booking_id, changes):
 			except Exception as e:
 				return validation_error(f"Invalid changes format: {e!s}")
 
+		# Tenant isolation: scoped users may only modify their own bookings.
+		if frappe.db.exists("Cheese Route Booking", route_booking_id):
+			try:
+				assert_record_access("Cheese Route Booking", route_booking_id)
+			except frappe.PermissionError:
+				return _permission_denied("Not permitted to modify this route booking")
+
 		# Apply changes using ticket modification
 		from cheese.api.v1.ticket_controller import modify_ticket
 
@@ -1635,6 +1653,11 @@ def get_available_slots_for_route(route_id, selected_date=None, date_from=None, 
 
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
+
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return _permission_denied("Not permitted to access this route")
 
 		route = frappe.get_doc("Cheese Route", route_id)
 		if route.status != "ONLINE":

--- a/cheese/api/v1/route_controller.py
+++ b/cheese/api/v1/route_controller.py
@@ -19,6 +19,11 @@ from cheese.api.v1.bank_account_controller import get_active_bank_account_doc
 from cheese.api.v1.deposit_controller import _amount_remaining_for_deposit, _select_open_deposit
 from cheese.api.v1.route_booking_controller import _check_experiences_combinable
 from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.access import (
+	assert_route_access,
+	assert_record_access,
+	assert_experience_access,
+)
 
 
 def _duration_to_seconds(duration_value):
@@ -162,6 +167,12 @@ def create_route(
 			if not frappe.db.exists("Cheese Experience", exp.get("experience")):
 				return not_found("Experience", exp.get("experience"))
 
+			# Tenant isolation: scoped users may only build routes from their own experiences.
+			try:
+				assert_experience_access(exp.get("experience"))
+			except frappe.PermissionError:
+				return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 			# Check if experience is eligible for routes
 			exp_doc = frappe.get_doc("Cheese Experience", exp.get("experience"))
 			if exp_doc.package_mode not in ["Route", "Both"]:
@@ -264,6 +275,11 @@ def update_route(
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
 
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		route = frappe.get_doc("Cheese Route", route_id)
 
 		# Update fields
@@ -296,6 +312,12 @@ def update_route(
 				for exp in experiences_list:
 					if not frappe.db.exists("Cheese Experience", exp.get("experience")):
 						return not_found("Experience", exp.get("experience"))
+
+					# Tenant isolation: scoped users may only attach their own experiences.
+					try:
+						assert_experience_access(exp.get("experience"))
+					except frappe.PermissionError:
+						return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 					route.append(
 						"experiences",
@@ -370,6 +392,11 @@ def get_route_details(route_id):
 
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
+
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		route = frappe.get_doc("Cheese Route", route_id)
 
@@ -596,6 +623,11 @@ def publish_route(route_id):
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
 
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		route = frappe.get_doc("Cheese Route", route_id)
 
 		# Validate route has experiences
@@ -632,6 +664,11 @@ def unpublish_route(route_id):
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
 
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		route = frappe.get_doc("Cheese Route", route_id)
 		route.status = "OFFLINE"
 		route.save()
@@ -660,6 +697,11 @@ def archive_route(route_id):
 
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
+
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		route = frappe.get_doc("Cheese Route", route_id)
 		route.status = "ARCHIVED"
@@ -695,6 +737,11 @@ def configure_route_deposit(
 
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
+
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		route = frappe.get_doc("Cheese Route", route_id)
 
@@ -762,6 +809,11 @@ def configure_route_bank_account(route_id, bank_account_data):
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
 
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		# Parse bank account data
 		if isinstance(bank_account_data, str):
 			bank_data = json.loads(bank_account_data)
@@ -825,6 +877,11 @@ def get_route_deposit_instructions(route_booking_id):
 
 		if not frappe.db.exists("Cheese Route Booking", route_booking_id):
 			return not_found("Route Booking", route_booking_id)
+
+		try:
+			assert_record_access("Cheese Route Booking", route_booking_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		route_booking = frappe.get_doc("Cheese Route Booking", route_booking_id)
 		route = frappe.get_doc("Cheese Route", route_booking.route)
@@ -947,6 +1004,11 @@ def record_route_deposit_payment(route_booking_id, amount, verification_method="
 		if not frappe.db.exists("Cheese Route Booking", route_booking_id):
 			return not_found("Route Booking", route_booking_id)
 
+		try:
+			assert_record_access("Cheese Route Booking", route_booking_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		# Get deposit
 		deposit_name = _select_open_deposit("Cheese Route Booking", route_booking_id)
 
@@ -1000,6 +1062,11 @@ def get_route_bank_account(route_id):
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
 
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		bank_account = get_active_bank_account_doc("Cheese Route", route_id)
 		if not bank_account:
 			return not_found("Bank Account", f"for route {route_id}")
@@ -1040,6 +1107,11 @@ def get_experiences_by_route(route_id):
 
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
+
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		experiences = frappe.get_all(
 			"Cheese Route Experience",
@@ -1098,6 +1170,11 @@ def delete_route(route_id):
 
 		if not frappe.db.exists("Cheese Route", route_id):
 			return not_found("Route", route_id)
+
+		try:
+			assert_route_access(route_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		# Check for active bookings
 		active_bookings = frappe.db.count(

--- a/cheese/api/v1/survey_controller.py
+++ b/cheese/api/v1/survey_controller.py
@@ -5,6 +5,8 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime
 from cheese.api.common.responses import success, created, error, not_found, validation_error
+from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.access import assert_record_access, assert_company_value
 
 
 @frappe.whitelist()
@@ -54,6 +56,11 @@ def send_survey(ticket_id):
 
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
@@ -137,6 +144,11 @@ def submit_survey(ticket_id, rating, comment=None):
 
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		# Get or create survey response
 		survey_name = frappe.db.get_value(
@@ -234,7 +246,13 @@ def get_survey_analytics(date_from=None, date_to=None, route_id=None, establishm
 		
 		date_from_obj = getdate(date_from)
 		date_to_obj = getdate(date_to)
-		
+
+		# Tenant isolation: block param-override, then force the scoped company.
+		assert_company_value(establishment_id)
+		user_company = _get_current_user_company()
+		if user_company:
+			establishment_id = user_company
+
 		# Build filters
 		filters = {}
 		
@@ -333,7 +351,20 @@ def export_survey_results(format="CSV", filters=None):
 				filter_dict = json.loads(filters) if isinstance(filters, str) else filters
 			except Exception:
 				pass
-		
+
+		# Tenant isolation: scope surveys to tickets owned by the user's company.
+		user_company = _get_current_user_company()
+		if user_company:
+			company_ticket_ids = frappe.get_all(
+				"Cheese Ticket", filters={"company": user_company}, pluck="name"
+			)
+			if not company_ticket_ids:
+				return success(
+					f"Export data prepared ({format} format)",
+					{"format": format, "count": 0, "data": [], "note": "No data for this establishment"},
+				)
+			filter_dict["ticket"] = ["in", company_ticket_ids]
+
 		surveys = frappe.get_all(
 			"Cheese Survey Response",
 			filters=filter_dict,
@@ -403,7 +434,12 @@ def create_support_ticket_from_survey(survey_id, complaint_text):
 		# Get ticket and contact
 		if not survey.ticket:
 			return validation_error("Survey has no associated ticket")
-		
+
+		try:
+			assert_record_access("Cheese Ticket", survey.ticket)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", survey.ticket)
 		contact_id = ticket.contact
 		

--- a/cheese/api/v1/ticket_controller.py
+++ b/cheese/api/v1/ticket_controller.py
@@ -9,6 +9,12 @@ from cheese.cheese.utils.validation import validate_booking_policy
 from cheese.cheese.utils.capacity import update_slot_capacity, get_available_capacity
 from cheese.api.common.responses import success, created, error, not_found, validation_error
 from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.access import (
+	assert_record_access,
+	assert_experience_access,
+	assert_company_value,
+	scope_filters,
+)
 import json
 
 
@@ -206,6 +212,12 @@ def create_pending_ticket(contact_id, experience_id, slot_id, party_size=1, sele
 		if not frappe.db.exists("Cheese Experience Slot", slot_id):
 			return not_found("Slot", slot_id)
 
+		# Tenant isolation: a scoped user may only book their own establishment's experiences.
+		try:
+			assert_experience_access(experience_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		# Get slot and experience
 		slot = frappe.get_doc("Cheese Experience Slot", slot_id)
 		experience = frappe.get_doc("Cheese Experience", experience_id)
@@ -347,6 +359,11 @@ def modify_reservation_preview(reservation_id, new_slot=None, party_size=None, s
 		if not frappe.db.exists("Cheese Ticket", reservation_id):
 			return not_found("Reservation", reservation_id)
 		
+		try:
+			assert_record_access("Cheese Ticket", reservation_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", reservation_id)
 		
 		if ticket.status not in ["PENDING", "CONFIRMED"]:
@@ -471,6 +488,11 @@ def modify_ticket(ticket_id, new_slot=None, party_size=None, selected_date=None)
 
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
@@ -607,6 +629,11 @@ def cancel_ticket(ticket_id):
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
 
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
 		if ticket.status not in ["PENDING", "CONFIRMED"]:
@@ -667,6 +694,11 @@ def get_ticket_summary(ticket_id):
 
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		slot = frappe.get_doc("Cheese Experience Slot", ticket.slot)
@@ -740,6 +772,11 @@ def record_customer_notes(ticket_id, notes, append=False):
 		if not notes_text:
 			return validation_error("notes cannot be empty")
 
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		current_notes = (ticket.notes or "").strip()
 		append_flag = cint(append) == 1 if not isinstance(append, bool) else append
@@ -783,6 +820,11 @@ def confirm_ticket(ticket_id):
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
 		
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
 		if ticket.status != "PENDING":
@@ -861,6 +903,11 @@ def reject_ticket(ticket_id, reason=None):
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
 		
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
 		if ticket.status != "PENDING":
@@ -1071,7 +1118,7 @@ def get_reservations_by_phone(phone, page=1, page_size=20, status=None):
 			)
 
 		contact = contact[0]
-		filters = {"contact": contact.name}
+		filters = scope_filters({"contact": contact.name})
 		if status:
 			filters["status"] = status
 
@@ -1282,6 +1329,11 @@ def update_ticket_status(ticket_id, new_status, reason=None):
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
 		
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		old_status = ticket.status
 		
@@ -1343,6 +1395,11 @@ def mark_no_show(ticket_id, reason=None):
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
 		
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
+
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 		
 		if ticket.status not in ["CONFIRMED", "CHECKED_IN"]:
@@ -1387,7 +1444,13 @@ def get_establishment_ticket_board(establishment_id, date=None):
 	"""
 	try:
 		from frappe.utils import getdate, today
-		
+
+		# Tenant isolation: scoped users may only view their own establishment's
+		# board regardless of the establishment_id passed by the client.
+		user_company = _get_current_user_company()
+		if user_company:
+			establishment_id = user_company
+
 		if not establishment_id:
 			return validation_error("establishment_id is required")
 		
@@ -1473,6 +1536,11 @@ def convert_ticket_to_booking(ticket_id, route_id=None):
 
 		if not frappe.db.exists("Cheese Ticket", ticket_id):
 			return not_found("Ticket", ticket_id)
+
+		try:
+			assert_record_access("Cheese Ticket", ticket_id)
+		except frappe.PermissionError:
+			return error("Unauthorized", "UNAUTHORIZED", {}, 403)
 
 		ticket = frappe.get_doc("Cheese Ticket", ticket_id)
 

--- a/cheese/api/v1/user_controller.py
+++ b/cheese/api/v1/user_controller.py
@@ -30,10 +30,18 @@ def _get_user_companies(user_email):
 
 
 def _get_current_user_company():
-    """Get the company for the currently logged-in user (for scoped access)."""
+    """Get the company for the currently logged-in user (for scoped access).
+
+    Super admins (Route Administrator / System Manager / Central Admin /
+    Administrator) are never scoped and return ``None`` meaning "all
+    companies". Establishment-level (Level 2) users are scoped to their single
+    assigned company.
+    """
+    from cheese.cheese.utils.permissions import _is_super_admin
+
     user = frappe.session.user
-    if user == "Administrator":
-        return None  # Admin sees everything
+    if _is_super_admin(user):
+        return None  # super admins see everything
     companies = _get_user_companies(user)
     return companies[0] if companies else None
 

--- a/cheese/cheese/utils/access.py
+++ b/cheese/cheese/utils/access.py
@@ -1,12 +1,216 @@
 # Copyright (c) 2026
 # License: MIT
-"""API-level access checks for tenant-scoped Cheese resources."""
+"""API-level access checks for tenant-scoped Cheese resources.
+
+These helpers provide a single, consistent enforcement layer for the custom
+whitelisted API endpoints. The custom endpoints use ``frappe.get_all`` /
+``frappe.get_doc`` / ``frappe.db.*`` which bypass the doctype-level
+``permission_query_conditions`` / ``has_permission`` hooks, so isolation must
+be applied explicitly here.
+
+Super admins (Route Administrator / System Manager / Central Admin /
+Administrator) are never scoped; establishment-level (Level 2) users are
+scoped to their single assigned company.
+"""
 
 from typing import Optional
 
 import frappe
 
 from cheese.api.v1.user_controller import _get_current_user_company
+from cheese.cheese.utils.permissions import _is_super_admin, get_user_companies
+
+
+def current_scope_company() -> Optional[str]:
+	"""Return the company the current user is scoped to, or ``None`` for super admins.
+
+	A scoped user with no assigned company also returns ``None`` from
+	``_get_current_user_company``; callers that must hide everything in that
+	case should use :func:`scope_filters` which inserts an impossible filter.
+	"""
+	return _get_current_user_company()
+
+
+def _user_companies() -> list:
+	"""All companies the current (non-super-admin) user may access."""
+	return get_user_companies(frappe.session.user)
+
+
+def scope_filters(filters: Optional[dict] = None, field: str = "company") -> dict:
+	"""Inject a company constraint into a ``frappe.get_all`` filters dict.
+
+	* Super admins: filters returned unchanged.
+	* Scoped user with a company: ``filters[field] = company``.
+	* Scoped user with NO company: ``filters[field]`` is set to an impossible
+	  value so the query returns nothing (fail closed).
+	"""
+	filters = dict(filters or {})
+	if _is_super_admin(frappe.session.user):
+		return filters
+	company = _get_current_user_company()
+	if company:
+		filters[field] = company
+	else:
+		filters[field] = "__no_company_for_user__"
+	return filters
+
+
+def assert_company_value(company: Optional[str]) -> None:
+	"""Block parameter-override leaks.
+
+	Raise ``PermissionError`` when a scoped user passes a ``company`` /
+	``establishment_id`` that is not one of their assigned companies. Super
+	admins may pass any company.
+	"""
+	if _is_super_admin(frappe.session.user):
+		return
+	if not company:
+		return
+	allowed = set(_user_companies())
+	if company not in allowed:
+		frappe.throw(frappe._("Unauthorized"), frappe.PermissionError)
+
+
+def _resolve_record_company(doctype: str, name: str) -> Optional[str]:
+	"""Resolve the owning company of a record across the known link shapes.
+
+	Mirrors the SQL relationships used by ``permissions.py``:
+	  * direct ``company`` field (Cheese Ticket / Experience / Slot / etc.)
+	  * Cheese Route          -> via a linked experience's company
+	  * Cheese Route Booking  -> via a child ticket's company
+	  * dynamic entity records (Cheese Deposit / Document / Bank Account)
+	    -> resolve entity_type/entity_id
+	"""
+	meta = frappe.get_meta(doctype)
+
+	if meta.has_field("company"):
+		return frappe.db.get_value(doctype, name, "company")
+
+	if doctype == "Cheese Route":
+		exp = frappe.get_all(
+			"Cheese Route Experience",
+			filters={"parent": name, "parenttype": "Cheese Route"},
+			pluck="experience",
+			limit=1,
+		)
+		if exp:
+			return frappe.db.get_value("Cheese Experience", exp[0], "company")
+		return None
+
+	if doctype == "Cheese Route Booking":
+		ticket = frappe.get_all(
+			"Cheese Route Booking Ticket",
+			filters={"parent": name, "parenttype": "Cheese Route Booking"},
+			pluck="ticket",
+			limit=1,
+		)
+		if ticket:
+			return frappe.db.get_value("Cheese Ticket", ticket[0], "company")
+		return None
+
+	entity_type, entity_id = frappe.db.get_value(
+		doctype, name, ["entity_type", "entity_id"]
+	) or (None, None)
+	if entity_type and entity_id:
+		return _resolve_entity_company(entity_type, entity_id)
+	return None
+
+
+def _resolve_entity_company(entity_type: str, entity_id: str) -> Optional[str]:
+	"""Resolve company for a dynamic entity_type/entity_id pair."""
+	if entity_type == "Company":
+		return entity_id
+	if entity_type in ("Cheese Experience", "Cheese Ticket"):
+		return frappe.db.get_value(entity_type, entity_id, "company")
+	if entity_type == "Cheese Route":
+		return _resolve_record_company("Cheese Route", entity_id)
+	if entity_type == "Cheese Route Booking":
+		return _resolve_record_company("Cheese Route Booking", entity_id)
+	return None
+
+
+def assert_record_access(doctype: str, name: str) -> None:
+	"""Raise ``PermissionError`` when the current user may not access ``name``.
+
+	Ownerless records (no resolvable company) are allowed through, matching the
+	lenient behavior of :func:`assert_slot_access` for legacy data.
+	"""
+	if _is_super_admin(frappe.session.user):
+		return
+	user_company = _get_current_user_company()
+	if not user_company:
+		return
+	record_company = _resolve_record_company(doctype, name)
+	if not record_company:
+		return
+	if record_company != user_company:
+		frappe.throw(frappe._("Unauthorized"), frappe.PermissionError)
+
+
+def assert_contact_access(contact_id: str) -> None:
+	"""Raise ``PermissionError`` when the current user may not access a contact.
+
+	Cheese Contact uses a many-to-many ``companies`` child table. A contact
+	with no company links is treated as ownerless and allowed through (legacy
+	data); otherwise at least one linked company must match the user's company.
+	"""
+	if _is_super_admin(frappe.session.user):
+		return
+	user_company = _get_current_user_company()
+	if not user_company:
+		return
+	linked = frappe.get_all(
+		"Cheese Contact Company",
+		filters={"parent": contact_id, "parenttype": "Cheese Contact"},
+		pluck="company",
+	)
+	if linked and user_company not in linked:
+		frappe.throw(frappe._("Unauthorized"), frappe.PermissionError)
+
+
+def assert_entity_access(entity_type: str, entity_id: str) -> None:
+	"""Ownership assert for a dynamic entity_type/entity_id pair."""
+	if _is_super_admin(frappe.session.user):
+		return
+	user_company = _get_current_user_company()
+	if not user_company:
+		return
+	record_company = _resolve_entity_company(entity_type, entity_id)
+	if not record_company:
+		return
+	if record_company != user_company:
+		frappe.throw(frappe._("Unauthorized"), frappe.PermissionError)
+
+
+def assert_route_access(route_id: str) -> None:
+	"""Raise ``PermissionError`` when the current user may not access a route.
+
+	Routes can be cross-establishment: a route is visible to a user when at
+	least one of its experiences belongs to the user's company (mirrors
+	``permissions.has_route_permission``). Routes with no experiences are
+	treated as ownerless and allowed through.
+	"""
+	if _is_super_admin(frappe.session.user):
+		return
+	user_company = _get_current_user_company()
+	if not user_company:
+		return
+	exp_ids = frappe.get_all(
+		"Cheese Route Experience",
+		filters={"parent": route_id, "parenttype": "Cheese Route"},
+		pluck="experience",
+	)
+	if not exp_ids:
+		return
+	exp_companies = set(
+		frappe.get_all(
+			"Cheese Experience",
+			filters={"name": ["in", exp_ids]},
+			pluck="company",
+		)
+	)
+	if user_company not in exp_companies:
+		frappe.throw(frappe._("Unauthorized"), frappe.PermissionError)
 
 
 def _slot_company(slot) -> Optional[str]:

--- a/cheese/cheese/utils/permissions.py
+++ b/cheese/cheese/utils/permissions.py
@@ -340,6 +340,105 @@ def cheese_contact_query(user):
     )
 
 
+def cheese_message_query(user):
+    """Messages are scoped via the linked contact's companies or conversation company."""
+    if _is_super_admin(user):
+        return ""
+
+    companies = get_user_companies(user)
+    table = "tabCheese Message"
+    if not companies:
+        return _none_visible(table)
+
+    quoted = _quote_list(companies)
+    return (
+        f"(`{table}`.contact IN ("
+        f"SELECT parent FROM `tabCheese Contact Company` "
+        f"WHERE parenttype = 'Cheese Contact' AND company IN ({quoted}))"
+        f" OR `{table}`.conversation IN ("
+        f"SELECT name FROM `tabConversation` WHERE company IN ({quoted})))"
+    )
+
+
+def cheese_complaint_query(user):
+    """Complaints are scoped via the linked ticket's company or contact's companies."""
+    if _is_super_admin(user):
+        return ""
+
+    companies = get_user_companies(user)
+    table = "tabCheese Complaint"
+    if not companies:
+        return _none_visible(table)
+
+    quoted = _quote_list(companies)
+    return (
+        f"(`{table}`.ticket IN ("
+        f"SELECT name FROM `tabCheese Ticket` WHERE company IN ({quoted}))"
+        f" OR `{table}`.contact IN ("
+        f"SELECT parent FROM `tabCheese Contact Company` "
+        f"WHERE parenttype = 'Cheese Contact' AND company IN ({quoted})))"
+    )
+
+
+def cheese_system_event_query(user):
+    """Audit events scoped via their dynamic entity link.
+
+    Events whose ``entity_type`` is not a recognised tenant-scoped doctype are
+    hidden from establishment users (fail closed). Super admins see everything.
+    """
+    if _is_super_admin(user):
+        return ""
+
+    companies = get_user_companies(user)
+    table = "tabCheese System Event"
+    if not companies:
+        return _none_visible(table)
+
+    quoted = _quote_list(companies)
+    return (
+        f"("
+        f"(`{table}`.entity_type = 'Company' AND `{table}`.entity_id IN ({quoted}))"
+        f" OR (`{table}`.entity_type = 'Cheese Experience' AND `{table}`.entity_id IN ("
+        f"   SELECT name FROM `tabCheese Experience` WHERE company IN ({quoted})))"
+        f" OR (`{table}`.entity_type = 'Cheese Ticket' AND `{table}`.entity_id IN ("
+        f"   SELECT name FROM `tabCheese Ticket` WHERE company IN ({quoted})))"
+        f" OR (`{table}`.entity_type = 'Conversation' AND `{table}`.entity_id IN ("
+        f"   SELECT name FROM `tabConversation` WHERE company IN ({quoted})))"
+        f" OR (`{table}`.entity_type = 'Cheese Contact' AND `{table}`.entity_id IN ("
+        f"   SELECT parent FROM `tabCheese Contact Company` "
+        f"   WHERE parenttype = 'Cheese Contact' AND company IN ({quoted})))"
+        f")"
+    )
+
+
+def cheese_route_experience_query(user):
+    """Route-experience child rows scoped via the linked experience's company."""
+    if _is_super_admin(user):
+        return ""
+
+    companies = get_user_companies(user)
+    table = "tabCheese Route Experience"
+    if not companies:
+        return _none_visible(table)
+
+    quoted = _quote_list(companies)
+    return f"`{table}`.experience IN (SELECT name FROM `tabCheese Experience` WHERE company IN ({quoted}))"
+
+
+def cheese_quotation_experience_query(user):
+    """Quotation-experience child rows scoped via the linked experience's company."""
+    if _is_super_admin(user):
+        return ""
+
+    companies = get_user_companies(user)
+    table = "tabCheese Quotation Experience"
+    if not companies:
+        return _none_visible(table)
+
+    quoted = _quote_list(companies)
+    return f"`{table}`.experience IN (SELECT name FROM `tabCheese Experience` WHERE company IN ({quoted}))"
+
+
 # ---------------------------------------------------------------------------
 # has_permission callbacks (per-document checks for get_doc / form view)
 # ---------------------------------------------------------------------------
@@ -507,3 +606,86 @@ def has_deposit_permission(doc, ptype="read", user=None):
 		)
 		return bool(ticket_companies & companies)
 	return False
+
+
+def _contact_companies(contact: Optional[str]) -> set:
+	if not contact:
+		return set()
+	return set(
+		frappe.get_all(
+			"Cheese Contact Company",
+			filters={"parent": contact, "parenttype": "Cheese Contact"},
+			pluck="company",
+		)
+	)
+
+
+def has_message_permission(doc, ptype="read", user=None):
+	user = user or frappe.session.user
+	if _is_super_admin(user):
+		return True
+	companies = set(get_user_companies(user))
+	if not companies:
+		return False
+	if _contact_companies(doc.get("contact")) & companies:
+		return True
+	if doc.get("conversation"):
+		conv_company = frappe.db.get_value("Conversation", doc.conversation, "company")
+		if conv_company in companies:
+			return True
+	return False
+
+
+def has_complaint_permission(doc, ptype="read", user=None):
+	user = user or frappe.session.user
+	if _is_super_admin(user):
+		return True
+	companies = set(get_user_companies(user))
+	if not companies:
+		return False
+	if doc.get("ticket"):
+		ticket_company = frappe.db.get_value("Cheese Ticket", doc.ticket, "company")
+		if ticket_company in companies:
+			return True
+	return bool(_contact_companies(doc.get("contact")) & companies)
+
+
+def has_system_event_permission(doc, ptype="read", user=None):
+	user = user or frappe.session.user
+	if _is_super_admin(user):
+		return True
+	companies = set(get_user_companies(user))
+	if not companies:
+		return False
+	entity_type, entity_id = doc.get("entity_type"), doc.get("entity_id")
+	if not entity_type or not entity_id:
+		return False
+	if entity_type == "Company":
+		return entity_id in companies
+	if entity_type in ("Cheese Experience", "Cheese Ticket"):
+		return frappe.db.get_value(entity_type, entity_id, "company") in companies
+	if entity_type == "Conversation":
+		return frappe.db.get_value("Conversation", entity_id, "company") in companies
+	if entity_type == "Cheese Contact":
+		return bool(_contact_companies(entity_id) & companies)
+	return False
+
+
+def _experience_company_in(experience: Optional[str], companies: set) -> bool:
+	if not experience:
+		return False
+	return frappe.db.get_value("Cheese Experience", experience, "company") in companies
+
+
+def has_route_experience_permission(doc, ptype="read", user=None):
+	user = user or frappe.session.user
+	if _is_super_admin(user):
+		return True
+	companies = set(get_user_companies(user))
+	if not companies:
+		return False
+	return _experience_company_in(doc.get("experience"), companies)
+
+
+def has_quotation_experience_permission(doc, ptype="read", user=None):
+	return has_route_experience_permission(doc, ptype, user)

--- a/cheese/hooks.py
+++ b/cheese/hooks.py
@@ -139,6 +139,11 @@ permission_query_conditions = {
 	"Cheese Route": "cheese.cheese.utils.permissions.cheese_route_query",
 	"Cheese Quotation": "cheese.cheese.utils.permissions.cheese_quotation_query",
 	"Cheese Deposit": "cheese.cheese.utils.permissions.cheese_deposit_query",
+	"Cheese Message": "cheese.cheese.utils.permissions.cheese_message_query",
+	"Cheese Complaint": "cheese.cheese.utils.permissions.cheese_complaint_query",
+	"Cheese System Event": "cheese.cheese.utils.permissions.cheese_system_event_query",
+	"Cheese Route Experience": "cheese.cheese.utils.permissions.cheese_route_experience_query",
+	"Cheese Quotation Experience": "cheese.cheese.utils.permissions.cheese_quotation_experience_query",
 }
 
 has_permission = {
@@ -160,6 +165,11 @@ has_permission = {
 	"Cheese Route": "cheese.cheese.utils.permissions.has_route_permission",
 	"Cheese Quotation": "cheese.cheese.utils.permissions.has_company_permission",
 	"Cheese Deposit": "cheese.cheese.utils.permissions.has_deposit_permission",
+	"Cheese Message": "cheese.cheese.utils.permissions.has_message_permission",
+	"Cheese Complaint": "cheese.cheese.utils.permissions.has_complaint_permission",
+	"Cheese System Event": "cheese.cheese.utils.permissions.has_system_event_permission",
+	"Cheese Route Experience": "cheese.cheese.utils.permissions.has_route_experience_permission",
+	"Cheese Quotation Experience": "cheese.cheese.utils.permissions.has_quotation_experience_permission",
 }
 
 # DocType Class

--- a/cheese/test_access_isolation.py
+++ b/cheese/test_access_isolation.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2026
+# License: MIT
+"""Permission tests for the centralized tenant-isolation helpers.
+
+These exercise ``cheese.cheese.utils.access`` directly to confirm that a
+Level-2 "Establishment User" is scoped to a single company while super admins
+(Administrator / Route Administrator) remain unrestricted.
+
+Run with: bench --site <site> run-tests --app cheese \
+    --module cheese.test_access_isolation
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from cheese.cheese.utils.access import (
+	assert_company_value,
+	assert_contact_access,
+	assert_experience_access,
+	assert_record_access,
+	assert_route_access,
+	current_scope_company,
+	scope_filters,
+)
+
+COMPANY_A = "Cheese ISO Company A"
+COMPANY_B = "Cheese ISO Company B"
+EST_USER = "cheese_iso_est_user@example.com"
+# Roles a real establishment user receives (see user_controller.create_user):
+# "Cheese Establishment User" drives single-company scoping, "Cheese Booking
+# Agent" grants the doctype read access tested below.
+EST_ROLES = ("Establishment User", "Cheese Establishment User", "Cheese Booking Agent")
+
+
+def _ensure_company(name, abbr):
+	if frappe.db.exists("Company", name):
+		return name
+	frappe.get_doc(
+		{
+			"doctype": "Company",
+			"company_name": name,
+			"abbr": abbr,
+			"default_currency": "USD",
+			"country": "United States",
+		}
+	).insert(ignore_permissions=True, ignore_if_duplicate=True)
+	return name
+
+
+def _ensure_experience(name, company):
+	if frappe.db.exists("Cheese Experience", name):
+		frappe.db.set_value("Cheese Experience", name, "company", company)
+		return name
+	doc = frappe.get_doc(
+		{
+			"doctype": "Cheese Experience",
+			"name": name,
+			"company": company,
+			"description": f"{name} desc",
+			"individual_price": 100.0,
+			"package_mode": "Both",
+			"status": "ONLINE",
+		}
+	)
+	doc.set_new_name()
+	doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
+	return doc.name
+
+
+def _ensure_route(name, experience):
+	if frappe.db.exists("Cheese Route", name):
+		return name
+	doc = frappe.get_doc(
+		{
+			"doctype": "Cheese Route",
+			"name": name,
+			"short_description": name,
+			"description": f"{name} desc",
+			"status": "ONLINE",
+			"price_mode": "Sum",
+			"experiences": [
+				{
+					"doctype": "Cheese Route Experience",
+					"experience": experience,
+					"sequence": 1,
+				}
+			],
+		}
+	)
+	doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
+	return doc.name
+
+
+def _ensure_system_event(experience):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Cheese System Event",
+			"entity_type": "Cheese Experience",
+			"entity_id": experience,
+			"event_type": "TICKET_CREATED",
+			"payload_json": "{}",
+			"created_at": frappe.utils.now_datetime(),
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _ensure_contact(phone, company):
+	existing = frappe.get_all("Cheese Contact", filters={"phone": phone}, pluck="name")
+	if existing:
+		return existing[0]
+	doc = frappe.get_doc(
+		{
+			"doctype": "Cheese Contact",
+			"full_name": f"Contact {phone}",
+			"phone": phone,
+			"companies": [{"doctype": "Cheese Contact Company", "company": company}],
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestTenantIsolationHelpers(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_company(COMPANY_A, "CISOA")
+		_ensure_company(COMPANY_B, "CISOB")
+
+		cls.exp_a = _ensure_experience("Cheese ISO Exp A", COMPANY_A)
+		cls.exp_b = _ensure_experience("Cheese ISO Exp B", COMPANY_B)
+		cls.route_a = _ensure_route("Cheese ISO Route A", cls.exp_a)
+		cls.route_b = _ensure_route("Cheese ISO Route B", cls.exp_b)
+		cls.contact_a = _ensure_contact("+100000000001", COMPANY_A)
+		cls.contact_b = _ensure_contact("+100000000002", COMPANY_B)
+
+		cls.event_a = _ensure_system_event(cls.exp_a)
+		cls.event_b = _ensure_system_event(cls.exp_b)
+
+		for role in EST_ROLES:
+			if not frappe.db.exists("Role", role):
+				frappe.get_doc({"doctype": "Role", "role_name": role}).insert(
+					ignore_permissions=True, ignore_if_duplicate=True
+				)
+
+		if not frappe.db.exists("User", EST_USER):
+			user = frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": EST_USER,
+					"first_name": "ISO",
+					"last_name": "Establishment",
+					"enabled": 1,
+					"user_type": "System User",
+					"send_welcome_email": 0,
+				}
+			)
+			user.insert(ignore_permissions=True)
+		else:
+			user = frappe.get_doc("User", EST_USER)
+		_existing_roles = {r.role for r in user.roles}
+		_added = False
+		for role in EST_ROLES:
+			if role not in _existing_roles:
+				user.append("roles", {"role": role})
+				_added = True
+		if _added:
+			user.save(ignore_permissions=True)
+
+		if not frappe.db.exists(
+			"User Permission", {"user": EST_USER, "allow": "Company", "for_value": COMPANY_A}
+		):
+			frappe.get_doc(
+				{
+					"doctype": "User Permission",
+					"user": EST_USER,
+					"allow": "Company",
+					"for_value": COMPANY_A,
+					"apply_to_all_doctypes": 1,
+				}
+			).insert(ignore_permissions=True)
+
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	# -- establishment user is scoped to company A -------------------------
+
+	def test_current_scope_company_for_establishment_user(self):
+		frappe.set_user(EST_USER)
+		self.assertEqual(current_scope_company(), COMPANY_A)
+
+	def test_scope_filters_injects_company(self):
+		frappe.set_user(EST_USER)
+		self.assertEqual(scope_filters({"status": "PENDING"}), {"status": "PENDING", "company": COMPANY_A})
+
+	def test_assert_company_value_blocks_other_company(self):
+		frappe.set_user(EST_USER)
+		assert_company_value(COMPANY_A)  # own company: no raise
+		with self.assertRaises(frappe.PermissionError):
+			assert_company_value(COMPANY_B)
+
+	def test_assert_experience_access(self):
+		frappe.set_user(EST_USER)
+		assert_experience_access(self.exp_a)
+		with self.assertRaises(frappe.PermissionError):
+			assert_experience_access(self.exp_b)
+
+	def test_assert_record_access_experience(self):
+		frappe.set_user(EST_USER)
+		assert_record_access("Cheese Experience", self.exp_a)
+		with self.assertRaises(frappe.PermissionError):
+			assert_record_access("Cheese Experience", self.exp_b)
+
+	def test_assert_route_access(self):
+		frappe.set_user(EST_USER)
+		assert_route_access(self.route_a)
+		with self.assertRaises(frappe.PermissionError):
+			assert_route_access(self.route_b)
+
+	def test_assert_contact_access(self):
+		frappe.set_user(EST_USER)
+		assert_contact_access(self.contact_a)
+		with self.assertRaises(frappe.PermissionError):
+			assert_contact_access(self.contact_b)
+
+	# -- list views never expose another company's rows -------------------
+
+	def test_experience_list_is_scoped(self):
+		frappe.set_user(EST_USER)
+		names = frappe.get_list("Cheese Experience", pluck="name", limit_page_length=0)
+		self.assertIn(self.exp_a, names)
+		self.assertNotIn(self.exp_b, names)
+
+	def test_route_list_is_scoped(self):
+		frappe.set_user(EST_USER)
+		names = frappe.get_list("Cheese Route", pluck="name", limit_page_length=0)
+		self.assertIn(self.route_a, names)
+		self.assertNotIn(self.route_b, names)
+
+	def test_system_event_list_is_scoped(self):
+		frappe.set_user(EST_USER)
+		names = frappe.get_list("Cheese System Event", pluck="name", limit_page_length=0)
+		self.assertIn(self.event_a, names)
+		self.assertNotIn(self.event_b, names)
+
+	# -- super admins are never scoped ------------------------------------
+
+	def test_admin_is_unscoped(self):
+		frappe.set_user("Administrator")
+		self.assertIsNone(current_scope_company())
+		self.assertEqual(scope_filters({"status": "PENDING"}), {"status": "PENDING"})
+		# No raises regardless of company.
+		assert_company_value(COMPANY_B)
+		assert_experience_access(self.exp_b)
+		assert_record_access("Cheese Experience", self.exp_b)
+		assert_route_access(self.route_b)
+		assert_contact_access(self.contact_b)

--- a/cheese/tmp_scope_check.py
+++ b/cheese/tmp_scope_check.py
@@ -1,0 +1,61 @@
+import frappe
+
+
+def count_of(resp):
+    data = resp.get("data") if isinstance(resp, dict) else resp
+    if isinstance(data, dict) and "data" in data:
+        data = data["data"]
+    return len(data) if isinstance(data, list) else data
+
+
+def run():
+    from cheese.api.v1 import (
+        experience_controller as exp,
+        route_controller as rc,
+        ticket_controller as tc,
+        route_booking_controller as rbc,
+        deposit_controller as dc,
+        contact_controller as cc,
+        lead_controller as lc,
+        quotation_controller as qc,
+        conversation_controller as conv,
+        attendance_controller as ac,
+        survey_controller as sc,
+        complaint_controller as cpc,
+        document_controller as doc,
+    )
+
+    calls = {
+        "experiences": lambda: exp.list_experiences(page_size=500),
+        "routes": lambda: rc.list_routes(page_size=500),
+        "tickets": lambda: tc.list_tickets(page_size=500),
+        "route_bookings": lambda: rbc.list_route_bookings(page_size=500),
+        "deposits": lambda: dc.list_deposits(page_size=500),
+        "contacts": lambda: cc.list_contacts(page_size=500),
+        "leads": lambda: lc.list_leads(page_size=500),
+        "quotations": lambda: qc.list_quotations(page_size=500),
+        "conversations": lambda: conv.list_conversations(page_size=500),
+        "attendance": lambda: ac.list_attendance(page_size=500),
+        "surveys": lambda: sc.list_survey_responses(page_size=500),
+        "complaints": lambda: cpc.list_complaints(page_size=500),
+        "documents": lambda: doc.list_documents(page_size=500),
+    }
+
+    results = {}
+    for user in ["Administrator", "yosef@yosef.com"]:
+        frappe.set_user(user)
+        results[user] = {}
+        for label, fn in calls.items():
+            try:
+                results[user][label] = count_of(fn())
+            except Exception as e:
+                results[user][label] = f"ERR {type(e).__name__}: {e}"
+
+    print("\n%-18s %12s %12s %s" % ("LIST", "ADMIN", "YOSEF", "LEAK?"))
+    for label in calls:
+        a = results["Administrator"][label]
+        y = results["yosef@yosef.com"][label]
+        leak = ""
+        if isinstance(a, int) and isinstance(y, int):
+            leak = "<-- LEAK" if (y == a and a > 0) else "ok"
+        print("%-18s %12s %12s %s" % (label, a, y, leak))


### PR DESCRIPTION
- Added new permission checks for Cheese Message, Complaint, System Event, Route Experience, and Quotation Experience in hooks.py.
- Implemented assert_record_access and assert_contact_access in attendance, bank account, booking, complaint, contact, conversation, deposit, experience, hotel, itinerary, lead, opt-in, pricing, quotation, route booking, and other controllers to ensure proper access control.
- Improved tenant isolation by enforcing company-specific filters in multiple queries across controllers.
- Enhanced error handling for unauthorized access attempts, returning appropriate error responses.

These changes improve security and ensure that users can only access data relevant to their company.